### PR TITLE
Change go cli build to trigger on publish

### DIFF
--- a/.github/workflows/release-go-cli.yaml
+++ b/.github/workflows/release-go-cli.yaml
@@ -3,7 +3,7 @@ name: Create and release go binaries for linux, windows and mac
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   build:


### PR DESCRIPTION
The current trigger isn't working and it makes sense to rather trigger once a release is published