### PR TITLE
Only display env var table if there are env vars

### DIFF
--- a/instant.ts
+++ b/instant.ts
@@ -136,7 +136,9 @@ const logPackageDetails = (packageInfo: PackageInfo) => {
       'Updated Value': env[envVar]
     })
   }
-  console.table(envVars)
+  if (envVars?.length > 0) {
+    console.table(envVars)
+  }
 }
 
 // Main script execution


### PR DESCRIPTION
Empty tables get displayed when no env vars are present

This PR only renders a table if there are env vars to display