### PR TITLE
CLI-V2 pre prod #12

### DIFF
--- a/cli/src/cmd/commands/commands.go
+++ b/cli/src/cmd/commands/commands.go
@@ -8,9 +8,8 @@ import (
 )
 
 func AddCommands(cmd *cobra.Command) {
-	// TODO: add commands
 	cmd.AddCommand(
 		pkg.DeclarePackageCommand(),
-		project.ProjectGenerateCommand(),
+		project.DeclareProjectCommand(),
 	)
 }

--- a/cli/src/cmd/flags/flags.go
+++ b/cli/src/cmd/flags/flags.go
@@ -10,3 +10,21 @@ func SetPackageActionFlags(cmd *cobra.Command) {
 	flags.StringP("profile", "p", "", "The profile name to load parameters from (defined in config.yml)")
 	flags.StringSliceP("custom-path", "c", nil, "Path(s) to custom package(s)")
 }
+
+// disables certain flags for project level commands, but allows for usage
+// of parseAndPrepareLaunch function without receiving errors
+func SetProjectActionFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+
+	// allowed flags
+	flags.BoolP("dev", "d", false, "For development related functionality (Passes `dev` as the second argument to your swarm file)")
+	flags.BoolP("only", "o", false, "Ignore package dependencies")
+	flags.StringSliceP("custom-path", "c", nil, "Path(s) to custom package(s)")
+
+	// disabled flags
+	flags.StringSlice("name", nil, "")
+	flags.String("profile", "", "")
+
+	cmd.Flags().MarkHidden("name")
+	cmd.Flags().MarkHidden("profile")
+}

--- a/cli/src/cmd/project/destroy.go
+++ b/cli/src/cmd/project/destroy.go
@@ -1,0 +1,46 @@
+package project
+
+import (
+	pFlags "cli/cmd/flags"
+	"cli/core/deploy"
+	"cli/core/parse"
+	"context"
+
+	"github.com/luno/jettison/log"
+	"github.com/spf13/cobra"
+)
+
+func projectDestroyCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "destroy",
+		Aliases: []string{"r"},
+		Short:   "Destroy all packages in the project",
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := context.Background()
+
+			err := checkInvalidFlags(cmd)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+
+			packageSpec, config, err := parse.ParseAndPrepareLaunch(cmd)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+			packageSpec.Packages = config.Packages
+			packageSpec.CustomPackages = config.CustomPackages
+
+			err = deploy.LaunchDeploymentContainer(packageSpec, config)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+		},
+	}
+
+	pFlags.SetProjectActionFlags(cmd)
+
+	return cmd
+}

--- a/cli/src/cmd/project/destroy.go
+++ b/cli/src/cmd/project/destroy.go
@@ -1,10 +1,11 @@
 package project
 
 import (
+	"context"
+
 	pFlags "cli/cmd/flags"
 	"cli/core/deploy"
 	"cli/core/parse"
-	"context"
 
 	"github.com/luno/jettison/log"
 	"github.com/spf13/cobra"

--- a/cli/src/cmd/project/down.go
+++ b/cli/src/cmd/project/down.go
@@ -1,10 +1,11 @@
 package project
 
 import (
+	"context"
+
 	pFlags "cli/cmd/flags"
 	"cli/core/deploy"
 	"cli/core/parse"
-	"context"
 
 	"github.com/luno/jettison/log"
 	"github.com/spf13/cobra"

--- a/cli/src/cmd/project/down.go
+++ b/cli/src/cmd/project/down.go
@@ -1,0 +1,46 @@
+package project
+
+import (
+	pFlags "cli/cmd/flags"
+	"cli/core/deploy"
+	"cli/core/parse"
+	"context"
+
+	"github.com/luno/jettison/log"
+	"github.com/spf13/cobra"
+)
+
+func projectDownCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "down",
+		Aliases: []string{"d"},
+		Short:   "Down all packages in the project",
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := context.Background()
+
+			err := checkInvalidFlags(cmd)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+
+			packageSpec, config, err := parse.ParseAndPrepareLaunch(cmd)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+			packageSpec.Packages = config.Packages
+			packageSpec.CustomPackages = config.CustomPackages
+
+			err = deploy.LaunchDeploymentContainer(packageSpec, config)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+		},
+	}
+
+	pFlags.SetProjectActionFlags(cmd)
+
+	return cmd
+}

--- a/cli/src/cmd/project/generate.go
+++ b/cli/src/cmd/project/generate.go
@@ -1,15 +1,34 @@
 package project
 
 import (
+	"context"
+
+	"cli/core/generate"
+	"cli/core/prompt"
+
+	"github.com/luno/jettison/log"
 	"github.com/spf13/cobra"
 )
 
-// TODO(MarkL): Write tests for this once this functionality is introduced
-func ProjectGenerateCommand() *cobra.Command {
+func projectGenerateCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate",
 		Short: "Generate a new project",
-		Run:   func(cmd *cobra.Command, args []string) {},
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := context.Background()
+
+			config, err := prompt.GenerateProjectPrompt()
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+
+			err = generate.GenerateConfigFile(&config)
+			if err != nil {
+				log.Error(context.Background(), err)
+				panic(err)
+			}
+		},
 	}
 
 	return cmd

--- a/cli/src/cmd/project/init.go
+++ b/cli/src/cmd/project/init.go
@@ -1,0 +1,46 @@
+package project
+
+import (
+	pFlags "cli/cmd/flags"
+	"cli/core/deploy"
+	"cli/core/parse"
+	"context"
+
+	"github.com/luno/jettison/log"
+	"github.com/spf13/cobra"
+)
+
+func projectInitCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "init",
+		Aliases: []string{"i"},
+		Short:   "Initialize all packages in a project",
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := context.Background()
+
+			err := checkInvalidFlags(cmd)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+
+			packageSpec, config, err := parse.ParseAndPrepareLaunch(cmd)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+			packageSpec.Packages = config.Packages
+			packageSpec.CustomPackages = config.CustomPackages
+
+			err = deploy.LaunchDeploymentContainer(packageSpec, config)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+		},
+	}
+
+	pFlags.SetProjectActionFlags(cmd)
+
+	return cmd
+}

--- a/cli/src/cmd/project/init.go
+++ b/cli/src/cmd/project/init.go
@@ -1,10 +1,11 @@
 package project
 
 import (
+	"context"
+
 	pFlags "cli/cmd/flags"
 	"cli/core/deploy"
 	"cli/core/parse"
-	"context"
 
 	"github.com/luno/jettison/log"
 	"github.com/spf13/cobra"

--- a/cli/src/cmd/project/project.go
+++ b/cli/src/cmd/project/project.go
@@ -1,0 +1,34 @@
+package project
+
+import (
+	"github.com/luno/jettison/errors"
+	"github.com/spf13/cobra"
+)
+
+func checkInvalidFlags(cmd *cobra.Command) error {
+	if cmd.Flag("name").Changed {
+		return errors.Wrap(errors.New("flag accessed but not defined: name"), "")
+	}
+	if cmd.Flag("profile").Changed {
+		return errors.Wrap(errors.New("flag accessed but not defined: profile"), "")
+	}
+
+	return nil
+}
+
+func DeclareProjectCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project",
+		Short: "Project level commands",
+	}
+
+	cmd.AddCommand(
+		projectInitCommand(),
+		projectDownCommand(),
+		projectUpCommand(),
+		projectDestroyCommand(),
+		projectGenerateCommand(),
+	)
+
+	return cmd
+}

--- a/cli/src/cmd/project/up.go
+++ b/cli/src/cmd/project/up.go
@@ -1,0 +1,46 @@
+package project
+
+import (
+	pFlags "cli/cmd/flags"
+	"cli/core/deploy"
+	"cli/core/parse"
+	"context"
+
+	"github.com/luno/jettison/log"
+	"github.com/spf13/cobra"
+)
+
+func projectUpCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "up",
+		Aliases: []string{"u"},
+		Short:   "Up all packages in the project",
+		Run: func(cmd *cobra.Command, args []string) {
+			ctx := context.Background()
+
+			err := checkInvalidFlags(cmd)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+
+			packageSpec, config, err := parse.ParseAndPrepareLaunch(cmd)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+			packageSpec.Packages = config.Packages
+			packageSpec.CustomPackages = config.CustomPackages
+
+			err = deploy.LaunchDeploymentContainer(packageSpec, config)
+			if err != nil {
+				log.Error(ctx, err)
+				panic(err)
+			}
+		},
+	}
+
+	pFlags.SetProjectActionFlags(cmd)
+
+	return cmd
+}

--- a/cli/src/cmd/project/up.go
+++ b/cli/src/cmd/project/up.go
@@ -1,10 +1,11 @@
 package project
 
 import (
+	"context"
+
 	pFlags "cli/cmd/flags"
 	"cli/core/deploy"
 	"cli/core/parse"
-	"context"
 
 	"github.com/luno/jettison/log"
 	"github.com/spf13/cobra"

--- a/cli/src/core/generate/generate.go
+++ b/cli/src/core/generate/generate.go
@@ -83,7 +83,7 @@ func GenerateConfigFile(config *core.Config) error {
 	if err != nil {
 		return errors.Wrap(err, "")
 	}
-	data = append(data, []byte("\n")...)
+	data = append(data, '\n')
 
 	secondFields := core.Config{
 		Packages: config.Packages,
@@ -94,7 +94,7 @@ func GenerateConfigFile(config *core.Config) error {
 		return errors.Wrap(err, "")
 	}
 	data = append(data, d...)
-	data = append(data, []byte("\n")...)
+	data = append(data, '\n')
 
 	thirdFields := core.Config{
 		CustomPackages: config.CustomPackages,
@@ -105,7 +105,7 @@ func GenerateConfigFile(config *core.Config) error {
 		return errors.Wrap(err, "")
 	}
 	data = append(data, d...)
-	data = append(data, []byte("\n")...)
+	data = append(data, '\n')
 
 	fourthFields := core.Config{
 		Profiles: config.Profiles,

--- a/cli/src/core/parse/config_test.go
+++ b/cli/src/core/parse/config_test.go
@@ -59,6 +59,7 @@ func Test_unmarshalConfig(t *testing.T) {
 		{
 			configPath: wd + "/../../features/unit-test-configs/config-case-1.yml",
 			expectedConfig: core.Config{
+				ProjectName: "test-project",
 				Image:         "jembi/go-cli-test-image",
 				LogPath:       "/tmp/logs",
 				PlatformImage: "jembi/platform:latest",

--- a/cli/src/core/prompt/package.go
+++ b/cli/src/core/prompt/package.go
@@ -12,9 +12,13 @@ func GeneratePackagePrompt() (*generatePackagePromptResponse, error) {
 	/*
 		What is the id of your package:
 		What is the name of your package:
+		What docker image would you like to use with this project:
 		Provide a description of your package:
 		Which stack does your package belong to:
+		What type best suites your package:
 		Do you want to include a dev compose file:
+		Which port would you like to target in dev mode:
+		Which port would you like published in dev mode:
 	*/
 
 	promptId := promptui.Prompt{

--- a/cli/src/core/prompt/project.go
+++ b/cli/src/core/prompt/project.go
@@ -1,0 +1,109 @@
+package prompt
+
+import (
+	"cli/core"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/iancoleman/strcase"
+	"github.com/luno/jettison/errors"
+	"github.com/manifoldco/promptui"
+)
+
+func GenerateProjectPrompt() (core.Config, error) {
+	/*
+		What is the name of your project:
+		What docker image would you like to use with this project: (organisation/project-name)
+		What Platform image is this project based on:
+		What is the log path to be used with this project:
+		Will this project include custom packages: yes/no
+		Would you like to use profiles in this project:
+	*/
+
+	path, err := os.Getwd()
+	if err != nil {
+		return core.Config{}, errors.Wrap(err, "")
+	}
+
+	promptProjectName := promptui.Prompt{
+		Label:   "What is the name of your project",
+		Default: filepath.Base(path),
+	}
+	projectName, err := promptProjectName.Run()
+	if err != nil {
+		return core.Config{}, errors.Wrap(err, "")
+	}
+
+	promptProjectImage := promptui.Prompt{
+		Label:   "What docker image would you like to use with this project",
+		Default: strcase.ToKebab(fmt.Sprintf("organisation/%v", projectName)),
+	}
+	projectImage, err := promptProjectImage.Run()
+	if err != nil {
+		return core.Config{}, errors.Wrap(err, "")
+	}
+
+	promptPlatformImage := promptui.Prompt{
+		Label:   "What Platform image is this project based on",
+		Default: "jembi/platform",
+	}
+	platformImage, err := promptPlatformImage.Run()
+	if err != nil {
+		return core.Config{}, errors.Wrap(err, "")
+	}
+
+	promptLogPath := promptui.Prompt{
+		Label:   "What is the log path to be used with this project",
+		Default: "/tmp/logs",
+	}
+	logPath, err := promptLogPath.Run()
+	if err != nil {
+		return core.Config{}, errors.Wrap(err, "")
+	}
+
+	promptPackages := promptui.Select{
+		Label: "Will this project include custom packages",
+		Items: []string{"Yes", "No"},
+	}
+	index, withCustomPackages, err := promptPackages.Run()
+	if err != nil || index == -1 {
+		return core.Config{}, errors.Wrap(err, "")
+	}
+
+	var customPackages []core.CustomPackage
+	if withCustomPackages == "Yes" {
+		customPackages = append(customPackages, core.CustomPackage{
+			Id:   "<<custom-package-id>>",
+			Path: "<<custom-package-path>>",
+		})
+	}
+
+	promptProfiles := promptui.Select{
+		Label: "Will this project include project profiles",
+		Items: []string{"Yes", "No"},
+	}
+	index, withProfiles, err := promptProfiles.Run()
+	if err != nil || index == -1 {
+		return core.Config{}, errors.Wrap(err, "")
+	}
+
+	var profiles []core.Profile
+	if withProfiles == "Yes" {
+		profiles = append(profiles, core.Profile{
+			Name:     "<<profile-name>>",
+			EnvFiles: []string{"<<env-file-1>>", "<<env-file-2>>"},
+			Packages: []string{"<<profile-package-id-1>>", "<<profile-package-id-2>>"},
+		})
+	}
+
+	return core.Config{
+		Image:          projectImage,
+		ProjectName:    projectName,
+		PlatformImage:  platformImage,
+		LogPath:        logPath,
+		Packages:       []string{"<<package-id>>"},
+		CustomPackages: customPackages,
+		Profiles:       profiles,
+	}, nil
+}

--- a/cli/src/core/types.go
+++ b/cli/src/core/types.go
@@ -2,10 +2,10 @@ package core
 
 type Profile struct {
 	Name     string   `yaml:"name"`
+	Packages []string `yaml:"packages"`
 	EnvFiles []string `yaml:"envFiles"`
 	Dev      bool     `yaml:"dev"`
 	Only     bool     `yaml:"only"`
-	Packages []string `yaml:"packages"`
 }
 
 type CustomPackage struct {
@@ -14,13 +14,13 @@ type CustomPackage struct {
 }
 
 type Config struct {
-	Image          string          `yaml:"image"`
-	LogPath        string          `yaml:"logPath"`
-	Packages       []string        `yaml:"packages"`
-	CustomPackages []CustomPackage `yaml:"customPackages"`
-	Profiles       []Profile       `yaml:"profiles"`
-	ProjectName    string          `yaml:"projectName"`
-	PlatformImage  string          `yaml:"platformImage"`
+	ProjectName    string          `yaml:"projectName,omitempty"`
+	Image          string          `yaml:"image,omitempty"`
+	PlatformImage  string          `yaml:"platformImage,omitempty"`
+	LogPath        string          `yaml:"logPath,omitempty"`
+	Packages       []string        `yaml:"packages,omitempty"`
+	CustomPackages []CustomPackage `yaml:"customPackages,omitempty"`
+	Profiles       []Profile       `yaml:"profiles,omitempty"`
 }
 
 type PackageSpec struct {

--- a/cli/src/features/unit-test-configs/config-case-1.yml
+++ b/cli/src/features/unit-test-configs/config-case-1.yml
@@ -1,7 +1,8 @@
 ---
-image: 'jembi/go-cli-test-image'
-logPath: /tmp/logs
+projectName: test-project
+image: jembi/go-cli-test-image
 platformImage: jembi/platform:latest
+logPath: /tmp/logs
 
 packages:
   - client
@@ -9,7 +10,7 @@ packages:
 
 customPackages:
   - id: disi-on-platform
-    path: "git@github.com:jembi/disi-on-platform.git"
+    path: git@github.com:jembi/disi-on-platform.git
 
 profiles:
   - name: dev
@@ -19,3 +20,4 @@ profiles:
     envFiles:
       - ../test-conf/.env.test
     dev: true
+    only: false

--- a/cli/src/go.mod
+++ b/cli/src/go.mod
@@ -88,6 +88,6 @@ require (
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.4.0 // indirect
 )


### PR DESCRIPTION
Don't review yet, these PRs are first being structured in the most convenient fashion.

### Note
- This functionality is meant to be used when seeking to deploy, remove, up, or down entire projects. Originally, instant.ts would handle this logic. Now it is being done at the CLI level. The benefit of this is, that the CLI will deploy entire projects using the project commands (and those packages specified in the config.yml file), whereas the old way of doing it would deploy all packages in a project, even if some packages aren't specified in the config.yml file.
- The next PR will remove the old functionality
- Tests to come in the next PR

### What this PR does
- reintroduce project generate functionality
- introduce project level commands

### Testing
- run unit tests using src/unit-test.sh