### PR TITLE
Fix: Add check for docker creds file before trying to open

### DIFF
--- a/cli/src/core/deploy/deploy.go
+++ b/cli/src/core/deploy/deploy.go
@@ -136,6 +136,7 @@ func copyCredsToInstantContainer() (err error) {
 	}
 	dockerCredsPath := filepath.Join(homeDir, ".docker", "config.json")
 
+	_, err = os.Stat(dockerCredsPath)
 	if err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "")
 	} else if os.IsNotExist(err) {


### PR DESCRIPTION
To ensure an error isn't thrown for the users that don't use a creds file